### PR TITLE
Fix selenium webtest example

### DIFF
--- a/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
+++ b/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using TechTalk.SpecFlow;
+using TestApplication.UiTests.Drivers;
+using TestApplication.Web;
+
+namespace TestApplication.UiTests.Support
+{
+    [Binding]
+    public class Hooks
+    {
+        private static IHost _build;
+
+        [BeforeTestRun]
+        public static void StartKestrel(ConfigurationDriver configurationDriver)
+        {
+            _build = CreateHostBuilder(configurationDriver).Build();
+            _build.StartAsync();
+        }
+
+        [AfterTestRun]
+        public static void StopKestrel()
+        {
+            _build.StopAsync();
+        }
+
+        private static IHostBuilder CreateHostBuilder(ConfigurationDriver configurationDriver)
+        {
+            return Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseKestrel()
+                        .UseStartup<Startup>()
+                        .UseUrls(configurationDriver.SeleniumBaseUrl);
+                });
+        }
+    }
+
+
+}

--- a/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
+++ b/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
@@ -9,19 +9,19 @@ namespace TestApplication.UiTests.Support
     [Binding]
     public class Hooks
     {
-        private static IHost _build;
+        private static IHost _host;
 
         [BeforeTestRun]
         public static void StartKestrel(ConfigurationDriver configurationDriver)
         {
-            _build = CreateHostBuilder(configurationDriver).Build();
-            _build.StartAsync();
+            _host = CreateHostBuilder(configurationDriver).Build();
+            _host.StartAsync();
         }
 
         [AfterTestRun]
         public static void StopKestrel()
         {
-            _build.Dispose();
+            _host.Dispose();
         }
 
         private static IHostBuilder CreateHostBuilder(ConfigurationDriver configurationDriver)

--- a/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
+++ b/SeleniumWebTest/TestApplication.UiTests/Support/Hooks.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using TechTalk.SpecFlow;
 using TestApplication.UiTests.Drivers;
@@ -24,7 +21,7 @@ namespace TestApplication.UiTests.Support
         [AfterTestRun]
         public static void StopKestrel()
         {
-            _build.StopAsync();
+            _build.Dispose();
         }
 
         private static IHostBuilder CreateHostBuilder(ConfigurationDriver configurationDriver)

--- a/SeleniumWebTest/TestApplication.UiTests/TestApplication.UiTests.csproj
+++ b/SeleniumWebTest/TestApplication.UiTests/TestApplication.UiTests.csproj
@@ -22,6 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Report\ReportTemplate.cshtml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="test-appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/SeleniumWebTest/TestApplication.UiTests/test-appsettings.json
+++ b/SeleniumWebTest/TestApplication.UiTests/test-appsettings.json
@@ -1,4 +1,4 @@
 {
-  "seleniumBaseUrl": "https://localhost:58909",
+  "seleniumBaseUrl": "http://localhost:58909",
   "browser": ""
 }

--- a/SeleniumWebTest/readme.md
+++ b/SeleniumWebTest/readme.md
@@ -3,7 +3,7 @@
 This is a example how to use SpecFlow and SpecFlow+Runner to run Selenium Web Tests for different Browsers.  
 The example is based on https://github.com/baseclass/Contrib.SpecFlow.Selenium.NUnit
 
-This example also takes a screenshot after each step and embeds the screnshot in the final report. Refer to the documentation [here] (http://www.specflow.org/plus/documentation/Tutorial:-Customising-Reports) for an explanation of how the screenshot's path is passed to the report.
+This example also takes a screenshot after each step and embeds the screnshot in the final report. Refer to the documentation [here](http://www.specflow.org/plus/documentation/Tutorial:-Customising-Reports) for an explanation of how the screenshot's path is passed to the report.
 
 There is an article covering this project [here](https://specflow.org/2019/targeting-multiple-browser-with-a-single-test-with-specflow-3/).
 


### PR DESCRIPTION
Fix Selenium Webtest example:
- Add hooks to start/stop kestrel
- Copy the report template to the output directory
- Use http instead of https on localhost - self signed cert error in the browsers